### PR TITLE
Add LOGOPS_FORMAT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ logger.debug('This is an example');
 ### Trace format
 
 This library incorporates three flavors of trace formatting:
-* "json": writes logs as JSON. 
+* "json": writes logs as JSON.
 * "pipe": writes logs separating fields with pipes. This is the default value in logops
 * "dev": for development, used if the 'de-facto' NODE_ENV variable is set to 'development'
 
@@ -79,6 +79,12 @@ logger.info('This is an example: %d', 5, {key:"value");
 logger.format = logger.formatters.dev;
 logger.info('This is an example: %d', 5, {key:"value"});
 //output: INFO This is an example: 5 { key: 'value' }
+```
+
+You can also enable 'json' format using an environment variable:
+
+```bash
+export LOGOPS_FORMAT=json
 ```
 
 ### Logger Level

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -171,10 +171,7 @@ module.exports = API = {
   /**
    * Return a String representation for a trace.
    *
-   * Checks the NODE_ENV variable 'LOGOPS_FORMAT'. to use the built-in
-   * format functions. If LOGOPS_FORMAT='json', it uses the JSON formatter.
-   *
-   * Otherwise, it checks the 'de-facto' NODE_ENV variable to use the built-in
+   * It checks the 'de-facto' NODE_ENV variable to use the built-in
    * format functions. If you execute your node app the following way:
    *   NODE_ENV=development node index.js
    * the logger will write traces for developers.
@@ -189,9 +186,7 @@ module.exports = API = {
    *
    * @return {String} The trace formatted
    */
-   format: process.env.LOGOPS_FORMAT === 'json' ?
-      formatters.json :
-      process.env.NODE_ENV === 'development' ? formatters.dev : formatters.pipe,
+   format: process.env.NODE_ENV === 'development' ? formatters.dev : formatters.pipe,
 
   /**
    * Return an Object containing the available formatters ("dev", "pipe", "json").
@@ -206,5 +201,12 @@ module.exports = API = {
    */
   formatters: formatters
 };
+
+if (['json', 'pipe', 'dev'].indexOf(process.env.LOGOPS_FORMAT) >= 0) {
+  /**
+   * Checks the variable 'LOGOPS_FORMAT' to use the built-in format functions.
+   */
+  module.exports.format = formatters[process.env.LOGOPS_FORMAT];
+}
 
 setLevel(DEFAULT_LEVEL);

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -170,16 +170,16 @@ module.exports = API = {
 
   /**
    * Return a String representation for a trace.
-   * Checks the 'de-facto' NODE_ENV variable to use the built-in
-   * format functions.
-   * Therefore, if you execute your node app the following way:
+   *
+   * Checks the NODE_ENV variable 'LOGOPS_FORMAT'. to use the built-in
+   * format functions. If LOGOPS_FORMAT='json', it uses the JSON formatter.
+   *
+   * Otherwise, it checks the 'de-facto' NODE_ENV variable to use the built-in
+   * format functions. If you execute your node app the following way:
    *   NODE_ENV=development node index.js
-   * the logger will write traces for developers
+   * the logger will write traces for developers.
    *
-   * Otherwise it will use JSON format by default.
-   *
-   * You can override this func and manage by yourself the formatting taking
-   * into account your own environment variables
+   * You can override this func and manage by yourself the formatting.
    *
    * @param {String} level One of the following values
    *      ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
@@ -189,9 +189,9 @@ module.exports = API = {
    *
    * @return {String} The trace formatted
    */
-  format: process.env.NODE_ENV === 'development' ?
-      formatters.dev :
-      formatters.pipe,
+   format: process.env.LOGOPS_FORMAT === 'json' ?
+      formatters.json :
+      process.env.NODE_ENV === 'development' ? formatters.dev : formatters.pipe,
 
   /**
    * Return an Object containing the available formatters ("dev", "pipe", "json").

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logops",
   "description": "Simple and performant nodejs logger",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "homepage": "",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logops",
   "description": "Simple and performant nodejs logger",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "",
   "license": "Apache-2.0",
   "author": {

--- a/test/unit/format_test.js
+++ b/test/unit/format_test.js
@@ -70,22 +70,37 @@ describe('Format traces with development environment', function() {
   });
 });
 
-describe('Select JSON traces', function() {
+describe('Select log format with an env variable', function() {
   before(function(done) {
+    delete process.env.LOGOPS_FORMAT;
+    done();
+  });
+
+  it('should select "json" format', function(done) {
     process.env.LOGOPS_FORMAT = 'json';
     logger = require('../../');
+
+    expect(logger.format).to.be.equal(logger.formatters.json);
     done();
   });
 
-  it('should log a simple message as JSON', function(done) {
-    var message = 'Sample Message';
-    var result = logger.format('INFO', context, message, []);
-    var resultJson = JSON.parse(result);
+  it('should select "dev" format', function(done) {
+    process.env.LOGOPS_FORMAT = 'dev';
+    logger = require('../../');
 
+    expect(logger.format).to.be.equal(logger.formatters.dev);
     done();
   });
 
-  after(function(done) {
+  it('should select "pipe" format', function(done) {
+    process.env.LOGOPS_FORMAT = 'pipe';
+    logger = require('../../');
+
+    expect(logger.format).to.be.equal(logger.formatters.pipe);
+    done();
+  });
+
+  afterEach(function(done) {
     delete require.cache[require.resolve('../../')];
     done();
   });

--- a/test/unit/format_test.js
+++ b/test/unit/format_test.js
@@ -6,6 +6,7 @@ require('colors');
 describe('Format traces with development environment', function() {
 
   before(function(done) {
+    delete process.env.LOGOPS_FORMAT;
     process.env.NODE_ENV = 'development';
     logger = require('../../');
     done();
@@ -64,6 +65,27 @@ describe('Format traces with development environment', function() {
 
   after(function(done) {
     process.env.NODE_ENV = 'production';
+    delete require.cache[require.resolve('../../')];
+    done();
+  });
+});
+
+describe('Select JSON traces', function() {
+  before(function(done) {
+    process.env.LOGOPS_FORMAT = 'json';
+    logger = require('../../');
+    done();
+  });
+
+  it('should log a simple message as JSON', function(done) {
+    var message = 'Sample Message';
+    var result = logger.format('INFO', context, message, []);
+    var resultJson = JSON.parse(result);
+
+    done();
+  });
+
+  after(function(done) {
     delete require.cache[require.resolve('../../')];
     done();
   });


### PR DESCRIPTION
JSON format can be enabled with an environment variable (```export LOGOPS_FORMAT=json```), with no need to change your code. Proposed as 0.3.1.