### PR TITLE
ADD formatters.setNotAvailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ logger.info('This is an example: %d', 5, {key:"value"});
 //output: INFO This is an example: 5 { key: 'value' }
 ```
 
+The "pipe" formatter uses "n/a" as the default value when a context field (corr, trans, op) is not found.
+You can change its value programmatically:
+
+```js
+logger.formatters.setNotAvailable('NA');
+logger.info('This is an example: %d', 5, {key:"value");
+//output: time=2015-06-11T08:36:16.628Z | lvl=INFO | corr=NA | trans=NA | op=NA | msg=This is an example: 5 { key: 'value' }
+```
+
 You can also set the format specifying the formatter with `LOGOPS_FORMAT` environment variable:
 
 ```bash

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -21,8 +21,18 @@
 
 var util = require('util');
 
-var notAvailable = 'n/a',
+var notAvailable,
     templateTrace = 'time=%s | lvl=%s | corr=%s | trans=%s | op=%s | msg=';
+
+/**
+ * Sets a value for those fields that are not available in the context. This field
+ * will only be used in the 'pipes' formatter.
+ *
+ * @param {String} na New value for not available fields.
+ */
+function setNotAvailable(na) {
+  notAvailable = na;
+}
 
 /**
  * Formats a trace message with some nice TTY colors
@@ -162,5 +172,6 @@ function formatJsonTrace(level, context, message, args) {
 module.exports = {
   pipe: formatTrace,
   dev: formatDevTrace,
-  json: formatJsonTrace
+  json: formatJsonTrace,
+  setNotAvailable: setNotAvailable
 };

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -21,7 +21,9 @@
 
 var util = require('util');
 
-var notAvailable,
+var DEFAULT_NOT_AVAILABLE = 'n/a';
+
+var notAvailable = DEFAULT_NOT_AVAILABLE,
     templateTrace = 'time=%s | lvl=%s | corr=%s | trans=%s | op=%s | msg=';
 
 /**

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -24,7 +24,6 @@ require('colors');
 
 var levels = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'],
     DEFAULT_LEVEL = 'INFO',
-    DEFAULT_NOT_AVAILABLE = 'n/a',
     API = {};
 
 /*
@@ -215,5 +214,4 @@ module.exports = API = {
   formatters: formatters
 };
 
-formatters.setNotAvailable(DEFAULT_NOT_AVAILABLE);
 setLevel(DEFAULT_LEVEL);

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -24,6 +24,7 @@ require('colors');
 
 var levels = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'],
     DEFAULT_LEVEL = 'INFO',
+    DEFAULT_NOT_AVAILABLE = 'n/a',
     API = {};
 
 /*
@@ -214,4 +215,5 @@ module.exports = API = {
   formatters: formatters
 };
 
+formatters.setNotAvailable(DEFAULT_NOT_AVAILABLE);
 setLevel(DEFAULT_LEVEL);

--- a/test/unit/format_test.js
+++ b/test/unit/format_test.js
@@ -89,6 +89,7 @@ describe('Select value for not available fields', function() {
   });
 
   after(function(done) {
+    logger.formatters.setNotAvailable('n/a'); // restore default value
     delete require.cache[require.resolve('../../')];
     done();
   });

--- a/test/unit/format_test.js
+++ b/test/unit/format_test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var logger = null, context = {};
+var logger = null,
+    context = {};
+
 require('colors');
 
 describe('Format traces with development environment', function() {
@@ -65,6 +67,28 @@ describe('Format traces with development environment', function() {
 
   after(function(done) {
     process.env.NODE_ENV = 'production';
+    delete require.cache[require.resolve('../../')];
+    done();
+  });
+});
+
+describe('Select value for not available fields', function() {
+  before(function(done) {
+    logger = require('../../');
+    done();
+  });
+
+  it('should log a custom value', function(done) {
+    logger.formatters.setNotAvailable('NOTAVAILABLE');
+
+    var result = logger.format('INFO', context, 'Message', []);
+    expect(result.indexOf('corr=NOTAVAILABLE')).to.be.gt(0);
+    expect(result.indexOf('trans=NOTAVAILABLE')).to.be.gt(0);
+    expect(result.indexOf('op=NOTAVAILABLE')).to.be.gt(0);
+    done();
+  });
+
+  after(function(done) {
     delete require.cache[require.resolve('../../')];
     done();
   });

--- a/test/unit/logops_test.js
+++ b/test/unit/logops_test.js
@@ -5,7 +5,7 @@ var logger = null;
 var levels = ['debug', 'info', 'warn', 'error', 'fatal'];
 var lastTraces = [];
 
-var NOT_AVAILABLE = 'n/a';
+var DEFAULT_NOT_AVAILABLE = 'n/a';
 
 var streamStub = {
   write: function(trace) {
@@ -46,9 +46,9 @@ describe('Logger Unit Tests', function() {
       expect(lastTraces).to.have.length(4);
       lastTraces.forEach(function(trace) {
         expect(trace.lvl).to.not.equal('DEBUG');
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal(message);
       });
       done();
@@ -70,9 +70,9 @@ describe('Logger Unit Tests', function() {
       expect(lastTraces).to.have.length(4);
       lastTraces.forEach(function(trace) {
         expect(trace.lvl).to.not.equal('DEBUG');
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal('Request is 5 {"key":"value"}');
       });
       done();
@@ -164,9 +164,9 @@ describe('Logger Unit Tests', function() {
       });
       expect(lastTraces).to.have.length(5);
       lastTraces.forEach(function(trace) {
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal(message);
       });
       done();
@@ -183,9 +183,9 @@ describe('Logger Unit Tests', function() {
       });
       expect(lastTraces).to.have.length(5);
       lastTraces.forEach(function(trace) {
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal('Request is 5 {"key":"value"}');
       });
       done();
@@ -279,9 +279,9 @@ describe('Logger Unit Tests', function() {
       lastTraces.forEach(function(trace) {
         expect(trace.lvl).to.not.equal('DEBUG');
         expect(trace.lvl).to.not.equal('INFO');
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal(message);
       });
       done();
@@ -304,9 +304,9 @@ describe('Logger Unit Tests', function() {
       lastTraces.forEach(function(trace) {
         expect(trace.lvl).to.not.equal('DEBUG');
         expect(trace.lvl).to.not.equal('INFO');
-        expect(trace.corr).to.be.equal(NOT_AVAILABLE);
-        expect(trace.trans).to.be.equal(NOT_AVAILABLE);
-        expect(trace.op).to.be.equal(NOT_AVAILABLE);
+        expect(trace.corr).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.trans).to.be.equal(DEFAULT_NOT_AVAILABLE);
+        expect(trace.op).to.be.equal(DEFAULT_NOT_AVAILABLE);
         expect(trace.msg).to.be.equal('Request is 5 {"key":"value"}');
       });
       done();


### PR DESCRIPTION
This is a function to set the value to be shown when a context field (trans, corr, op) is not found. This applies to the "pipes" formatter. This change is needed for those projects already using the "pipes" format with different values ("n/a", "NA", "na") that want to migrate to logops without breaking anything.

Expected usage:
```javascript
var logops = require('logops');
logops.formatters.setNotAvailable('NA');
```