### PR TITLE
[[FEAT]] print local context on dev format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ logger.info({key:"value"}, 'This is an example: %d', 5);
 // {"key":"value","time":"2015-12-23T11:55:27.041Z","lvl":"INFO","msg":"This is an example: 5"}
 
 logger.info({key:"value"}, 'This is an example: %d', 5);
-// INFO This is an example: 5
-// It only prints messages, but no context/properties
+// INFO This is an example: 5 { key: 'value' }
+// It only prints messages, but no context/properties get by logops.getContext()
 
 logger.format = logger.formatters.pipe; //DEPRECATED in v1.0.0
 logger.info({key:"value"}, 'This is an example: %d', 5);

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -58,33 +58,57 @@ function setNotAvailable(na) {
  * @param {Object} context Additional information to add to the trace
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
- * @param {Error|null} err A cause error used to log extra information
+ * @param {Error|undefined} err A cause error used to log extra information
+ * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  */
-function formatDevTrace(level, context, message, args, err) {
-  var str;
+function formatDevTrace(level, context, message, args, err, localctx) {
+  var str,
+      mainMessage = util.format.apply(global, [message].concat(args)),
+      printStack = API.stacktracesWith.indexOf(level) > -1;
+
   switch (level) {
     case 'DEBUG':
       str = colors.grey(level);
       break;
     case 'INFO':
-      str = colors.blue(level);
+      str = colors.blue(level) + ' '; // Pad to 5 chars
       break;
     case 'WARN':
-      str = colors.yellow(level);
+      str = colors.yellow(level) + ' '; // Pad to 5 chars
       break;
     case 'ERROR':
       str = colors.red(level);
       break;
     case 'FATAL':
-      str = colors.white.bold.redBG(level);
+      str = colors.red.bold(level);
       break;
   }
-  str += ' ';
-  str += util.format.apply(global, [message].concat(args));
-  str += err ? '\n' + serializeErr(err).toString(API.stacktracesWith.indexOf(level) > -1) : '';
-  return str;
+
+  str += ' ' + mainMessage;
+  // Add the localContext (ie. logger.info({local: 'context}, 'Message');
+  // as something printable. Forget about the context, as it will have mostly
+  // the same fields always
+  str += localctx ? ' ' + colorize(colors.gray, util.inspect(localctx)) : '';
+
+  // Add the error only if we need the stack or the error message is
+  // different fom the message one, i.e: logger.info(err, 'Custom Msg')
+  if (err && (mainMessage !== '' + err || printStack)) {
+    str += '\n' + colorize(colors.gray, serializeErr(err).toString(printStack));
+  }
+  // pad all subsequent lines with as much spaces as "DEBUG " or "INFO  " have
+  return str.replace(new RegExp('\r?\n','g'), '\n      ');
+}
+
+// Damm! colors are not applied to multilines! split, apply and join!
+function colorize(color, str) {
+  return str
+      .split('\n')
+      .map(function(part) {
+        return color(part);
+      })
+      .join('\n');
 }
 
 /**
@@ -97,12 +121,13 @@ function formatDevTrace(level, context, message, args, err) {
  * @param {Object} context Additional information to add to the trace
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
- * @param {Error|null} err A cause error used to log extra information
+ * @param {Error|undefined} err A cause error used to log extra information
+ * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  * @deprecated
  */
-function formatTrace(level, context, message, args, err) {
+function formatTrace(level, context, message, args, err, localctx) {
   args.unshift(
       templateTrace + message,
       (new Date()).toISOString(),
@@ -127,11 +152,13 @@ function formatTrace(level, context, message, args, err) {
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
  * @param {Error|null} err A cause error used to log extra information
+ * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  */
-function formatJsonTrace(level, context, message, args, err) {
-  var log = {};
+function formatJsonTrace(level, context, message, args, err, localctx) {
+  var log = {},
+      printStack = API.stacktracesWith.indexOf(level) > -1;
 
   for (var attrname in context) {
     log[attrname] = context[attrname];
@@ -139,9 +166,8 @@ function formatJsonTrace(level, context, message, args, err) {
 
   log.time = new Date();
   log.lvl = level;
-  log.err = err && serializeErr(err).toObject(API.stacktracesWith.indexOf(level) > -1);
+  log.err = err && serializeErr(err).toObject(printStack);
   log.msg = util.format.apply(global, [message].concat(args));
 
   return JSON.stringify(log);
 }
-

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -37,7 +37,7 @@ var toString = Object.prototype.toString,
  *   ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
  */
 function logWrap(level) {
-  var context, message, args, trace, err;
+  var context, localctx, message, args, trace, err;
 
   if (arguments[1] instanceof Error) {
     // log.<level>(err, ...)
@@ -63,12 +63,13 @@ function logWrap(level) {
     args = Array.prototype.slice.call(arguments, 2);
   } else {
     // log.<level>(fields, msg, ...)
+    localctx = arguments[1];
     context = merge(API.getContext(), arguments[1]);
     message = arguments[2];
     args = Array.prototype.slice.call(arguments, 3);
   }
 
-  trace = API.format(level, context || {}, message, args, err);
+  trace = API.format(level, context || {}, message, args, err, localctx);
   API.stream.write(trace + '\n');
 }
 


### PR DESCRIPTION
Print in dev traces the object passed as first argument to logops, to allow users to see what also be logged in the final JSON

```js
logger.info({local: 'context'}, 'Sample');
// {"local":"context","time":"2016-01-07T12:45:31.111Z","lvl":"INFO","msg":"Sample"}
logger.format = logger.formatters.dev
logger.info({local: 'context'}, 'Sample');
// INFO  Sample { local: 'context' }
```

Dev format omits the data passed in `logops.getContext` cause it will probably be the same in all traces and does not give any valuable information but noise