### PR TITLE
[[FEAT]] Omit context properties on dev format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,18 @@ This library incorporates two flavors of trace formatting:
 
 ```js
 logger.format = logger.formatters.json;
-logger.info({key:"value"}, 'This is an example: %d', 5);
+logger.info({key:'value'}, 'This is an example: %d', 5);
 // {"key":"value","time":"2015-12-23T11:55:27.041Z","lvl":"INFO","msg":"This is an example: 5"}
 
-logger.info({key:"value"}, 'This is an example: %d', 5);
-// INFO This is an example: 5 { key: 'value' }
-// It only prints messages, but no context/properties get by logops.getContext()
+logger.format = logger.formatters.dev;
+logger.info({key:'value'}, 'This is an example: %d', 5);
+// INFO  This is an example: 5 { key: 'value' }
 
 logger.format = logger.formatters.pipe; //DEPRECATED in v1.0.0
-logger.info({key:"value"}, 'This is an example: %d', 5);
+logger.info({key:'value'}, 'This is an example: %d', 5);
 // time=2015-12-23T11:57:24.879Z | lvl=INFO | corr=n/a | trans=n/a | op=n/a | msg=This is an example: 5
-
 ```
+
 You can also set the format specifying the formatter with `LOGOPS_FORMAT` environment variable:
 
 ```bash
@@ -122,7 +122,24 @@ export LOGOPS_FORMAT=json
 You can override the format function and manage by yourself the formatting taking into account your own environment variables by
 overriding the `logger.format` function
 
-### Error Stack traces
+### Don't print specific properties with `dev` format 
+
+Omit some boring/repeated/always-the-same context properties from being logged with the `dev` formatter:
+
+```js
+logger.format = logger.formatters.dev;
+logger.getContext = () => ({ pid: process.pid });
+logger.info({key:'value', ip:'127.0.0.1'}, 'This is an example: %d', 5);
+// INFO  This is an example: 5 { pid: 123342, key: 'value', ip: '127.0.0.1' }
+
+// Specify the context fields to omit as an array
+logger.formatters.dev.omit = ['pid', 'ip'];
+
+logger.info({key:'value', ip:'127.0.0.1'}, 'This is an example: %d', 5);
+// INFO  This is an example: 5 { key: 'value' }
+```
+
+### Don't print Error Stack traces
 
 Set `logger.formatters.stacktracesWith` array with the error levels that will print stacktraces. Default is `stacktracesWith: ['ERROR', 'FATAL']`
 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -21,7 +21,8 @@
 var util = require('util'),
     colors = require('colors/safe'),
     stringify = require('json-stringify-safe'),
-    serializeErr = require('serr');
+    serializeErr = require('serr'),
+    omit = require('lodash.omit');
 
 var DEFAULT_NOT_AVAILABLE = 'n/a';
 
@@ -60,11 +61,10 @@ function setNotAvailable(na) {
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
  * @param {Error|undefined} err A cause error used to log extra information
- * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  */
-function formatDevTrace(level, context, message, args, err, localctx) {
+function formatDevTrace(level, context, message, args, err) {
   var str,
       mainMessage = util.format.apply(global, [message].concat(args)),
       printStack = API.stacktracesWith.indexOf(level) > -1;
@@ -88,10 +88,11 @@ function formatDevTrace(level, context, message, args, err, localctx) {
   }
 
   str += ' ' + mainMessage;
-  // Add the localContext (ie. logger.info({local: 'context}, 'Message');
-  // as something printable. Forget about the context, as it will have mostly
-  // the same fields always
-  str += localctx ? ' ' + colorize(colors.gray, util.inspect(localctx)) : '';
+
+  var localContext = omit(context, formatDevTrace.omit);
+  str += Object.keys(localContext).length ?
+      ' ' + colorize(colors.gray, util.inspect(localContext)) :
+      '';
 
   // Add the error only if we need the stack or the error message is
   // different fom the message one, i.e: logger.info(err, 'Custom Msg')
@@ -101,6 +102,11 @@ function formatDevTrace(level, context, message, args, err, localctx) {
   // pad all subsequent lines with as much spaces as "DEBUG " or "INFO  " have
   return str.replace(new RegExp('\r?\n','g'), '\n      ');
 }
+/**
+ * Context properties that should be skipped from printing in dev format
+ * @type {Array.<String>}
+ */
+formatDevTrace.omit = [];
 
 // Damm! colors are not applied to multilines! split, apply and join!
 function colorize(color, str) {
@@ -123,12 +129,11 @@ function colorize(color, str) {
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
  * @param {Error|undefined} err A cause error used to log extra information
- * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  * @deprecated
  */
-function formatTrace(level, context, message, args, err, localctx) {
+function formatTrace(level, context, message, args, err) {
   args.unshift(
       templateTrace + message,
       (new Date()).toISOString(),
@@ -153,11 +158,10 @@ function formatTrace(level, context, message, args, err, localctx) {
  * @param {String} message The main message to be added to the trace
  * @param {Array} args More arguments provided to the log function
  * @param {Error|null} err A cause error used to log extra information
- * @param {Object|undefined} localctx The local object passed to a trace
  *
  * @return {String} The trace formatted
  */
-function formatJsonTrace(level, context, message, args, err, localctx) {
+function formatJsonTrace(level, context, message, args, err) {
   var log = {},
       printStack = API.stacktracesWith.indexOf(level) > -1;
 

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -37,7 +37,7 @@ var toString = Object.prototype.toString,
  *   ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
  */
 function logWrap(level) {
-  var context, localctx, message, args, trace, err;
+  var context, message, args, trace, err;
 
   if (arguments[1] instanceof Error) {
     // log.<level>(err, ...)
@@ -63,13 +63,12 @@ function logWrap(level) {
     args = Array.prototype.slice.call(arguments, 2);
   } else {
     // log.<level>(fields, msg, ...)
-    localctx = arguments[1];
     context = merge(API.getContext(), arguments[1]);
     message = arguments[2];
     args = Array.prototype.slice.call(arguments, 3);
   }
 
-  trace = API.format(level, context || {}, message, args, err, localctx);
+  trace = API.format(level, context || {}, message, args, err);
   API.stream.write(trace + '\n');
 }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "json-stringify-safe": "^5.0.1",
+    "lodash.omit": "^3.1.0",
     "serr": "^0.1.0"
   },
   "contributors": [

--- a/test/format.dev.spec.js
+++ b/test/format.dev.spec.js
@@ -75,24 +75,24 @@ describe('Development format', function() {
 
     it('should log objects representation', function() {
       logger.info({}, {});
-      expect(logger._lastTrace).to.be.eql('INFO  {} {}');
+      expect(logger._lastTrace).to.be.eql('INFO  {}');
     });
 
     it('should log nothing but context', function() {
       logger.info({});
-      expect(logger._lastTrace).to.be.eql('INFO  undefined {}');
+      expect(logger._lastTrace).to.be.eql('INFO  undefined');
     });
 
     it('should log dates', function() {
       var now = new Date();
       logger.info({}, now);
-      expect(logger._lastTrace).to.be.eql('INFO  ' + now + ' {}');
+      expect(logger._lastTrace).to.be.eql('INFO  ' + now);
     });
 
     it('should nothing but context with a Data as context', function() {
       var now = new Date();
       logger.info(now);
-      expect(logger._lastTrace).to.be.eql('INFO  undefined ' + now);
+      expect(logger._lastTrace).to.be.eql('INFO  undefined');
     });
 
     it('should log booleans', function() {
@@ -126,6 +126,22 @@ describe('Development format', function() {
       var ctx = {foo: 'bar'};
       logger.info(ctx, 'Hello %s!', 'darling');
       expect(logger._lastTrace).to.be.eql('INFO  Hello darling! ' + util.inspect(ctx));
+    });
+
+    it('should skip context information from trace', function() {
+      var prevOmit = logger.formatters.dev.omit,
+          prevGetContext = logger.getContext;
+
+      logger.getContext = function() { return { hostname: 'localhost' }; };
+
+      logger.formatters.dev.omit = ['hostname', 'pid'];
+
+      var ctx = { pid: 123, ip: '127.0.0.1' };
+      logger.info(ctx, 'Hello %s!', 'darling');
+      expect(logger._lastTrace).to.be.eql('INFO  Hello darling! { ip: \'127.0.0.1\' }');
+
+      logger.formatters.dev.omit = prevOmit;
+      logger.getContext = prevGetContext;
     });
   });
 


### PR DESCRIPTION
Dropped the bad feature of printing only localContext properties while in dev format, and added the more-generic one.

Now users that print the repeated info in every trace can omit them from the output also

```js
logger.format = logger.formatters.dev;
logger.getContext = () => ({ pid: process.pid });
logger.info({key:'value', ip:'127.0.0.1'}, 'This is an example: %d', 5);
// INFO  This is an example: 5 { pid: 123342, key: 'value', ip: '127.0.0.1' }

// Specify the context fields to omit as an array
logger.formatters.dev.omit = ['pid', 'ip'];

logger.info({key:'value', ip:'127.0.0.1'}, 'This is an example: %d', 5);
// INFO  This is an example: 5 { key: 'value' }
```