### PR TITLE
[[FEAT]] Dont use err.toString as message

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -96,7 +96,7 @@ function formatDevTrace(level, context, message, args, err) {
 
   // Add the error only if we need the stack or the error message is
   // different fom the message one, i.e: logger.info(err, 'Custom Msg')
-  if (err && (mainMessage !== '' + err || printStack)) {
+  if (err && ((mainMessage !== err.name + ': ' + err.message) || printStack)) {
     str += '\n' + colorize(colors.gray, serializeErr(err).toString(printStack));
   }
   // pad all subsequent lines with as much spaces as "DEBUG " or "INFO  " have

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -45,8 +45,8 @@ function logWrap(level) {
     args = Array.prototype.slice.call(arguments, 2);
     if (!args.length) {
       // log.<level>(err)
-      message = '' + arguments[1];
       err = arguments[1];
+      message = err.name + ': ' + err.message;
     } else {
       // log.<level>(err, "More %s", "things")
       // Use the err as context information

--- a/test/format.dev.spec.js
+++ b/test/format.dev.spec.js
@@ -206,5 +206,15 @@ describe('Development format', function() {
       ].join('\n')));
     });
 
+    it('should not use err.toString to serialize the message', function() {
+      var error = new Error('foo');
+      error.toString = function() {
+        return 'Overwrite';
+      };
+
+      logger.info(error);
+      expect(logger._lastTrace).to.be.eql(pad('INFO  Error: foo'));
+    });
+
   });
 });

--- a/test/format.json.spec.js
+++ b/test/format.json.spec.js
@@ -188,6 +188,23 @@ describe('JSON format', function() {
       }));
     });
 
+    it('should not use err.toString to serialize the message', function() {
+      var error = new Error('foo');
+      error.toString = function() {
+        return 'Overwrite';
+      };
+
+      logger.info(error);
+      expect(logger._lastTrace).to.be.eql(JSON.stringify({time: '1970-01-01T00:00:00.000Z', lvl: 'INFO',
+        err: {
+          message: 'foo',
+          name: 'Error',
+          constructor: 'Error'
+        },
+        msg: 'Error: foo'
+      }));
+    });
+
     it('should log errors with stacktrace', function() {
       var error = new Error('foo');
       error.custom = 'custom';


### PR DESCRIPTION
Node v6 adds the stacktrace when you call `new Error().toString`, which will break our test, and probably many logs analyzers that expects a different format

`Date` are also serialized in other ways

This is the first commit to try to mitigate this
