### PR TITLE
[[FIX]] Print error properties when no stacktraces in dev

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -67,7 +67,9 @@ function setNotAvailable(na) {
 function formatDevTrace(level, context, message, args, err) {
   var str,
       mainMessage = util.format.apply(global, [message].concat(args)),
-      printStack = API.stacktracesWith.indexOf(level) > -1;
+      printStack = API.stacktracesWith.indexOf(level) > -1,
+      errCommomMessage = err && (err.name + ': ' + err.message),
+      isErrorLoggingWithoutMessage = mainMessage === errCommomMessage;
 
   switch (level) {
     case 'DEBUG':
@@ -86,19 +88,22 @@ function formatDevTrace(level, context, message, args, err) {
       str = colors.red.bold(level);
       break;
   }
+  str += ' ';
 
-  str += ' ' + mainMessage;
+  if (isErrorLoggingWithoutMessage) {
+    str += colorize(colors.gray, serializeErr(err).toString(printStack));
+  } else {
+    str += mainMessage;
+    if (err) {
+      str += '\n' + colorize(colors.gray, serializeErr(err).toString(printStack));
+    }
+  }
 
   var localContext = omit(context, formatDevTrace.omit);
   str += Object.keys(localContext).length ?
       ' ' + colorize(colors.gray, util.inspect(localContext)) :
       '';
 
-  // Add the error only if we need the stack or the error message is
-  // different fom the message one, i.e: logger.info(err, 'Custom Msg')
-  if (err && ((mainMessage !== err.name + ': ' + err.message) || printStack)) {
-    str += '\n' + colorize(colors.gray, serializeErr(err).toString(printStack));
-  }
   // pad all subsequent lines with as much spaces as "DEBUG " or "INFO  " have
   return str.replace(new RegExp('\r?\n','g'), '\n      ');
 }

--- a/test/format.dev.spec.js
+++ b/test/format.dev.spec.js
@@ -149,6 +149,12 @@ describe('Development format', function() {
     function pad(str) {
       return str.replace(new RegExp('\r?\n','g'), '\n      ')
     }
+
+    function dropFirstLine(str) {
+      var arr = str.split('\n');
+      arr.shift();
+      return arr.join('\n');
+    }
     var colorsEnabled = colors.enabled;
     before(function() {
       colors.enabled = false;
@@ -159,14 +165,16 @@ describe('Development format', function() {
 
     it('should log errors without stacktrace', function() {
       var error = new Error('foo');
+      error.custom = true;
       logger.info(error);
-      expect(logger._lastTrace).to.be.eql(pad('INFO  Error: foo'));
+      expect(logger._lastTrace).to.be.eql(pad('INFO  Error: foo { custom: true }'));
     });
 
     it('should log errors with stacktrace', function() {
       var error = new Error('foo');
+      error.custom = true;
       logger.error(error);
-      expect(logger._lastTrace).to.be.eql(pad('ERROR Error: foo\n' + error.stack));
+      expect(logger._lastTrace).to.be.eql(pad('ERROR Error: foo { custom: true }\n' + dropFirstLine(error.stack)));
     });
 
     it('should log errors with stacktrace and cause', function() {
@@ -176,7 +184,7 @@ describe('Development format', function() {
       logger.error(error);
       expect(logger._lastTrace).to.be.eql(pad([
         'ERROR Error: foo',
-        error.stack,
+        dropFirstLine(error.stack),
         'Caused by: ' + error2.stack,
         'Caused by: ' + error3.stack
       ].join('\n')));


### PR DESCRIPTION
Make
```js 
var error = new Error('foo');
error.custom = true;
logger.info(error);
```
to print `'INFO  Error: foo { custom: true }'` instead of  `'INFO  Error: foo'`
to have better alignment between json and dev formatters.
This way, developers will see the error properties while in dev mode when an informational error happens