### PR TITLE
[[FEAT]] Support for ES6 module loaders

### DIFF
--- a/lib/logops.d.ts
+++ b/lib/logops.d.ts
@@ -4,6 +4,7 @@
  * The NODEJS stream where the logger will write string traces
  * Defaults to process.stdout
  */
+export function setStream(stream: NodeJS.WritableStream): void;
 export let stream: NodeJS.WritableStream;
 
 /**
@@ -21,7 +22,7 @@ export function getLevel(): Level;
  * so there is not any performance penalty at production using an undesired level
  * You can also set the logging level using the `LOGOPS_LEVEL` environment variable:
  * ```
- * $> LOGOPS_LEVEL=DEBUG node app.js 
+ * $> LOGOPS_LEVEL=DEBUG node app.js
  * ```
  *
  * @param level one of 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'
@@ -29,42 +30,44 @@ export function getLevel(): Level;
 export function setLevel(level: Level): void;
 
 /**
- * Gets a global context that should be printed and merged with specific
+ * Sets a global context that should be printed and merged with specific
  * log context props
  *
  * @example
  * ```
- * logops.getContext = function getContext() {
+ * logops.setContextGetter(function getContext() {
  *  return {
  *    hostname: require('os').hostname,
  *    pid: process.pid
  *  };
- * }
- * 
+ * });
+ *
  * logger.info({app: 'server'}, 'Startup');
- * // {"hostname":"host.local","pid":35502,"app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}     
+ * // {"hostname":"host.local","pid":35502,"app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
  * ```
  *  @return The context object
  */
+export function setContextGetter(getContext: () => Context): void;
 export function getContext(): Context;
 
 /**
  * Specifies the Formatter used for printing traces
  * @example
  * ```
- * logops.format = logops.formatters.dev;
+ * logops.setFormat(logops.formatters.dev);
  * ```
- * 
+ *
  * You can also set the format specifying the formatter with `LOGOPS_FORMAT` environment variable:
  * @example
  * ```
  * $> LOGOPS_FORMAT=json node app.js
  * ```
  */
+export function setFormat(format: Formatter): void;
 export let format: Formatter;
 
 /**
- * The available formatters 
+ * The available formatters
  */
 export let formatters: Formatters;
 
@@ -74,7 +77,7 @@ export let formatters: Formatters;
  * logger.debug({ip: '127.0.0.0'}, 'Something went wrong');
  * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"DEBUG","msg":"Something went wrong"}
  * ```
- * 
+ *
  * @param props the Context to print
  * @param format A printf-like format string as you will use in console.log()
  * @param params Additional properties to be coerced in the format string
@@ -82,27 +85,27 @@ export let formatters: Formatters;
 export function debug(props:Context, format?:string, ...params:any[]): void;
 
 /**
- * Logs an Error as a debug trace. 
+ * Logs an Error as a debug trace.
  * See Logops.stacktracesWith to print the stack traces
  * ```
  * logger.debug(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
  * ```
- * 
+ *
  * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log(). 
+ * @param format A printf-like format string as you will use in console.log().
  *  If not present, the message will be the Error message itself
  * @param params Additional properties to be coerced in the format string
  */
 export function debug(error:Error, format?:string, ...params:any[]): void;
 
 /**
- * Logs a debug trace, as you will do with console.log 
+ * Logs a debug trace, as you will do with console.log
  * ```
  * logger.debug('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
  * // {"time":"2015-12-22T16:31:56.184Z","lvl":"DEBUG","msg":"Request is 5 {\"key\":\"value\"} guy"}
  * ```
- * 
- * @param format A printf-like format string as you will use in console.log(). 
+ *
+ * @param format A printf-like format string as you will use in console.log().
  * @param params Additional properties to be coerced in the format string
  */
 export function debug(format:string, ...params:any[]): void;
@@ -113,7 +116,7 @@ export function debug(format:string, ...params:any[]): void;
  * logger.info({ip: '127.0.0.0'}, 'Something went wrong');
  * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"INFO","msg":"Something went wrong"}
  * ```
- * 
+ *
  * @param props the Context to print
  * @param format A printf-like format string as you will use in console.log()
  * @param params Additional properties to be coerced in the format string
@@ -121,27 +124,27 @@ export function debug(format:string, ...params:any[]): void;
 
 export function info(props:Context, format?:string, ...params:any[]): void;
 /**
- * Logs an Error as a info trace. 
+ * Logs an Error as a info trace.
  * See Logops.stacktracesWith to print the stack traces
  * ```
  * logger.info(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
  * ```
- * 
+ *
  * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log(). 
+ * @param format A printf-like format string as you will use in console.log().
  *  If not present, the message will be the Error message itself
  * @param params Additional properties to be coerced in the format string
  */
 export function info(error:Error, format?:string, ...params:any[]): void;
 
 /**
- * Logs a info trace, as you will do with console.log 
+ * Logs a info trace, as you will do with console.log
  * ```
  * logger.info('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
  * // {"time":"2015-12-22T16:31:56.184Z","lvl":"INFO","msg":"Request is 5 {\"key\":\"value\"} guy"}
  * ```
- * 
- * @param format A printf-like format string as you will use in console.log(). 
+ *
+ * @param format A printf-like format string as you will use in console.log().
  * @param params Additional properties to be coerced in the format string
  */
 export function info(format:string, ...params:any[]): void;
@@ -152,7 +155,7 @@ export function info(format:string, ...params:any[]): void;
  * logger.warn({ip: '127.0.0.0'}, 'Something went wrong');
  * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"WARN","msg":"Something went wrong"}
  * ```
- * 
+ *
  * @param props the Context to print
  * @param format A printf-like format string as you will use in console.log()
  * @param params Additional properties to be coerced in the format string
@@ -160,27 +163,27 @@ export function info(format:string, ...params:any[]): void;
 
 export function warn(props:Context, format?:string, ...params:any[]): void;
 /**
- * Logs an Error as a warn trace. 
+ * Logs an Error as a warn trace.
  * See Logops.stacktracesWith to print the stack traces
  * ```
  * logger.warn(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
  * ```
- * 
+ *
  * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log(). 
+ * @param format A printf-like format string as you will use in console.log().
  *  If not present, the message will be the Error message itself
  * @param params Additional properties to be coerced in the format string
  */
 export function warn(error:Error, format?:string, ...params:any[]): void;
 
 /**
- * Logs a warn trace, as you will do with console.log 
+ * Logs a warn trace, as you will do with console.log
  * ```
  * logger.warn('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
  * // {"time":"2015-12-22T16:31:56.184Z","lvl":"WARN","msg":"Request is 5 {\"key\":\"value\"} guy"}
  * ```
- * 
- * @param format A printf-like format string as you will use in console.log(). 
+ *
+ * @param format A printf-like format string as you will use in console.log().
  * @param params Additional properties to be coerced in the format string
  */
 export function warn(format:string, ...params:any[]): void;
@@ -191,7 +194,7 @@ export function warn(format:string, ...params:any[]): void;
  * logger.error({ip: '127.0.0.0'}, 'Something went wrong');
  * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"ERROR","msg":"Something went wrong"}
  * ```
- * 
+ *
  * @param props the Context to print
  * @param format A printf-like format string as you will use in console.log()
  * @param params Additional properties to be coerced in the format string
@@ -199,27 +202,27 @@ export function warn(format:string, ...params:any[]): void;
 export function error(props:Context, format?:string, ...params:any[]): void;
 
 /**
- * Logs an Error as an error trace. 
+ * Logs an Error as an error trace.
  * See Logops.stacktracesWith to print the stack traces
  * ```
  * logger.error(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
  * ```
- * 
+ *
  * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log(). 
+ * @param format A printf-like format string as you will use in console.log().
  *  If not present, the message will be the Error message itself
  * @param params Additional properties to be coerced in the format string
  */
 export function error(error:Error, format?:string, ...params:any[]): void;
 
 /**
- * Logs a error trace, as you will do with console.log 
+ * Logs a error trace, as you will do with console.log
  * ```
  * logger.error('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
  * // {"time":"2015-12-22T16:31:56.184Z","lvl":"ERROR","msg":"Request is 5 {\"key\":\"value\"} guy"}
  * ```
- * 
- * @param format A printf-like format string as you will use in console.log(). 
+ *
+ * @param format A printf-like format string as you will use in console.log().
  * @param params Additional properties to be coerced in the format string
  */
 export function error(format:string, ...params:any[]): void;
@@ -230,7 +233,7 @@ export function error(format:string, ...params:any[]): void;
  * logger.fatal({ip: '127.0.0.0'}, 'Something went wrong');
  * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"FATAL","msg":"Something went wrong"}
  * ```
- * 
+ *
  * @param props the Context to print
  * @param format A printf-like format string as you will use in console.log()
  * @param params Additional properties to be coerced in the format string
@@ -238,41 +241,41 @@ export function error(format:string, ...params:any[]): void;
 export function fatal(props:Context, format?:string, ...params:any[]): void;
 
 /**
- * Logs an Error as a debug trace. 
+ * Logs an Error as a debug trace.
  * See Logops.stacktracesWith to print the stack traces
  * ```
  * logger.fatal(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
  * ```
- * 
+ *
  * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log(). 
+ * @param format A printf-like format string as you will use in console.log().
  *  If not present, the message will be the Error message itself
  * @param params Additional properties to be coerced in the format string
  */
 export function fatal(error:Error, format?:string, ...params:any[]): void;
 
 /**
- * Logs a fatal trace, as you will do with console.log 
+ * Logs a fatal trace, as you will do with console.log
  * ```
  * logger.fatal('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
  * // {"time":"2015-12-22T16:31:56.184Z","lvl":"FATAL","msg":"Request is 5 {\"key\":\"value\"} guy"}
  * ```
- * 
- * @param format A printf-like format string as you will use in console.log(). 
+ *
+ * @param format A printf-like format string as you will use in console.log().
  * @param params Additional properties to be coerced in the format string
  */
 export function fatal(format:string, ...params:any[]): void;
 
 /**
- * A key value map that should be printed and serialized as first class 
- * citizien in the traces. 
+ * A key value map that should be printed and serialized as first class
+ * citizien in the traces.
  */
 interface Context {
     [key: string]: any;
 }
 
 /**
- * Interface for a logops formatter, that formats the user input as a readable 
+ * Interface for a logops formatter, that formats the user input as a readable
  * string ready to be written to a Stream
  */
 interface Formatter {
@@ -299,7 +302,7 @@ interface DevFormatter extends Formatter {
 }
 
 /**
- * The formatters interface. All relative to customization of how a trace 
+ * The formatters interface. All relative to customization of how a trace
  * is printed is located here
  */
 interface Formatters {
@@ -317,7 +320,7 @@ interface Formatters {
      */
     pipe: Formatter;
     /**
-     * Array of logger levels that will print error stacktraces 
+     * Array of logger levels that will print error stacktraces
      * Defaults to `['ERROR', 'FATAL']
      */
     stacktracesWith: Level[];

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -141,6 +141,9 @@ module.exports = API = {
    * Defaults to process.stdout
    */
   stream: process.stdout,
+  setStream: function(stream) {
+    API.stream = stream;
+  },
 
   /**
    * Sets the enabled logging level.
@@ -199,6 +202,9 @@ module.exports = API = {
    * @return {Object} The context object
    */
   getContext: noop,
+  setContextGetter: function(fn) {
+    API.getContext = fn;
+  },
 
   /**
    * Creates a string representation for a trace.
@@ -231,7 +237,9 @@ module.exports = API = {
    */
   format: formatters[process.env.LOGOPS_FORMAT] ||
     (process.env.NODE_ENV === 'development' ? formatters.dev : formatters.json),
-
+  setFormat: function(format) {
+    API.format = format
+  },
   /**
    * Return an Object containing the available formatters ("dev", "pipe", "json").
    *

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -238,7 +238,7 @@ module.exports = API = {
   format: formatters[process.env.LOGOPS_FORMAT] ||
     (process.env.NODE_ENV === 'development' ? formatters.dev : formatters.json),
   setFormat: function(format) {
-    API.format = format
+    API.format = format;
   },
   /**
    * Return an Object containing the available formatters ("dev", "pipe", "json").

--- a/test/logops.spec.js
+++ b/test/logops.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var logopsPath = '../lib/logops',
-    logger =require(logopsPath);
+    logger = require(logopsPath);
 
 describe('Select log format with an env variable', function() {
 
@@ -13,7 +13,6 @@ describe('Select log format with an env variable', function() {
     delete require.cache[require.resolve(logopsPath)];
     delete process.env.LOGOPS_FORMAT;
     delete process.env.NODE_ENV;
-
   });
 
   it('should select "json" format', function () {
@@ -239,5 +238,31 @@ describe('Get log format with the API', function() {
     logger.setLevel('DEBUG');
 
     expect(logger.getLevel()).to.equal('DEBUG');
+  });
+});
+
+describe('Setters', function() {
+  afterEach(function () {
+    delete require.cache[require.resolve(logopsPath)];
+  });
+
+  it('should set the context', function() {
+    function getContext() {
+      return { a: 1 };
+    }
+    logger.setContextGetter(getContext);
+    expect(logger.getContext).to.be.eql(getContext);
+  });
+
+  it('should set the format', function() {
+    var format = { };
+    logger.setFormat(format);
+    expect(logger.format).to.be.eql(format);
+  });
+
+  it('should set the stream', function() {
+    var stream = { };
+    logger.setStream(stream);
+    expect(logger.stream).to.be.eql(stream);
   });
 });

--- a/test/logops.typings.ts
+++ b/test/logops.typings.ts
@@ -5,15 +5,15 @@ let lvl = logops.getLevel();
 
 logops.setLevel(lvl);
 
-logops.getContext = function() {
-    return { a: 1 };
-};
+logops.setContextGetter(function() {
+  return { a: 1 };
+});
 
-logops.stream = process.stderr;
+logops.setStream(process.stderr);
 
-logops.format = logops.formatters.dev;
-logops.format = logops.formatters.json;
-logops.format = logops.formatters.pipe;
+logops.setFormat(logops.formatters.dev);
+logops.setFormat(logops.formatters.json);
+logops.setFormat(logops.formatters.pipe);
 
 logops.formatters.dev.omit = ['a'];
 logops.formatters.stacktracesWith = ['DEBUG'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "moduleResolution": "node",
         "target": "es5",
         "noImplicitAny": false,
         "sourceMap": false


### PR DESCRIPTION
The travis build https://travis-ci.org/telefonicaid/logops/jobs/164769769 bring to life an incompatibility with Typescript2/ES6 module loaders as stated in https://github.com/Microsoft/TypeScript/issues/6751

The issue can be solved in client code done in TypeScript2 by changing the import strategy from `import * as logops from 'logops'` to `import logops = require('logops')` or by creating getters in our side and let the TypeScript2/Babel/ES6 users to use those getters instead of modifying exported variables directly

So, TS2 users, they can use 
```ts
logops.setContextGetter(() => return { a: 1 });
logops.setStream(process.stderr);
logops.setFormat(logops.formatters.dev);
```
instead of 
```ts
logops.getContext = function() {
    return { a: 1 };
};
logops.stream = process.stderr;
logops.format = logops.formatters.dev;
```