### PR TITLE
chore: use arrow functions

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -41,6 +41,7 @@ var API = module.exports = {
   pipe: formatTrace, // Deprecated
   setNotAvailable: setNotAvailable // Deprecated
 };
+
 /**
  * Sets a value for those fields that are not available in the context. This field
  * will only be used in the 'pipes' formatter.
@@ -104,6 +105,7 @@ function formatDevTrace(level, context, message, args, err) {
   // pad all subsequent lines with as much spaces as "DEBUG " or "INFO  " have
   return str.replace(new RegExp('\r?\n','g'), '\n      ');
 }
+
 /**
  * Context properties that should be skipped from printing in dev format
  * @type {Array.<String>}
@@ -144,10 +146,10 @@ function formatTrace(level, context, message, args, err) {
   };
 
   Object.keys(context)
-      .filter(function(key) {
+      .filter((key) => {
         return !(context[key] && Object.prototype.toString.call(context[key]) === '[object Function]');
       })
-      .forEach(function(key) {
+      .forEach((key) => {
         recontext[key] = context[key] || notAvailable;
       });
 
@@ -159,9 +161,7 @@ function formatTrace(level, context, message, args, err) {
   }
 
   var str = Object.keys(recontext)
-      .map(function(key) {
-        return key + '=' + recontext[key];
-      })
+      .map((key) => key + '=' + recontext[key])
       .join(' | ');
 
   args.unshift(str);
@@ -189,7 +189,7 @@ function formatJsonTrace(level, context, message, args, err) {
 }
 
 formatJsonTrace.stringify = stringify;
-formatJsonTrace.toObject = function toObject(level, context, message, args, err) {
+formatJsonTrace.toObject = (level, context, message, args, err) => {
   const printStack = API.stacktracesWith.indexOf(level) > -1;
 
   return Object.assign({}, context, {

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -80,7 +80,7 @@ function logops() {
     currentLevel = level || DEFAULT_LEVEL;
     var logLevelIndex = levels.indexOf(currentLevel.toUpperCase());
 
-    levels.forEach(function(logLevel) {
+    levels.forEach((logLevel) => {
       var fn;
       if (logLevelIndex <= levels.indexOf(logLevel)) {
         fn = logWrap.bind(global, logLevel);
@@ -118,7 +118,7 @@ function logops() {
      * Defaults to process.stdout
      */
     stream: process.stdout,
-    setStream: function(stream) {
+    setStream: (stream) => {
       API.stream = stream;
     },
 
@@ -179,7 +179,7 @@ function logops() {
      * @return {Object} The context object
      */
     getContext: noop,
-    setContextGetter: function(fn) {
+    setContextGetter: (fn) => {
       API.getContext = fn;
     },
 
@@ -214,7 +214,7 @@ function logops() {
      */
     format: formatters[process.env.LOGOPS_FORMAT] ||
       (process.env.NODE_ENV === 'development' ? formatters.dev : formatters.json),
-    setFormat: function(format) {
+    setFormat: (format) => {
       API.format = format;
     },
     /**


### PR DESCRIPTION
Minor: Use ES6 arrow functions in logops code.