### PR TITLE
[[FEAT]] Child logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ logger.fatal(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
 
 * With the rest of arguments is just like calling `console.log`. It will be serialized as the trace message. Easy to remember.
 
+
 ## Context support
 
-Logops supports using global properties that will be merged with the specific ones defined in the call. Simply override the `logger.getContext` method to let the logger to get it.
+Logops supports using global properties that will be merged with the specific ones defined in the call. Simply override the `logger.getContext` method to let the logger to get it. See `logops.child` to see how to also create loggers with context 
 
 ```js
 var logger = require('logops'),
@@ -120,6 +121,29 @@ You can also set the format specifying the formatter with `LOGOPS_FORMAT` enviro
 export LOGOPS_FORMAT=json
 # export LOGOPS_FORMAT=dev
 ```
+
+## Child Loggers 
+You can create an specialized logger for a part of your app with bound static context/properties. The child logger
+will inherit its parent config: level, format, stream and context. If the parent logger has a context returned by `parent.getContext()`, the conflicting child logger context will take precedence
+```js
+let child = logger.child({component: 'client'});
+child.info('Startup');
+// {"component":"client","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
+```
+
+**TIP: Using with express/connect**
+You can create a simply middleware to add a logger to every request with something like
+```js
+app.use(function(req, res, next) {
+  req.logger = logger.child({
+    requestId: uuid.v4()
+  });
+  next();
+});
+```
+So your `req.logger` will log the requestId to allow correlation of traces in your server traces.
+
+_Note: setting `child.getContext` property, will override the context used to create the logger and its merge with its parent one. So you can use it to create a context free logger_
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ logger.fatal(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
 
 ## Context support
 
-Logops supports using global properties that will be merged with the specific ones defined in the call. Simply override the `logger.getContext` method to let the logger to get it. See `logops.child` to see how to also create loggers with context 
+Logops supports using global properties that will be merged with the specific ones defined in the call. Simply override the `logger.getContext` method to let the logger get it. See `logops.child` to see how to also create loggers with context 
 
 ```js
 var logger = require('logops'),

--- a/lib/logops.d.ts
+++ b/lib/logops.d.ts
@@ -1,277 +1,296 @@
 /** Simple and performant nodejs JSON logger */
 
-/**
- * The NODEJS stream where the logger will write string traces
- * Defaults to process.stdout
- */
-export function setStream(stream: NodeJS.WritableStream): void;
-export let stream: NodeJS.WritableStream;
+
+interface Logops {
+  /**
+   * The NODEJS stream where the logger will write string traces
+   * Defaults to process.stdout
+   */
+  setStream(stream: NodeJS.WritableStream): void;
+  stream: NodeJS.WritableStream;
+
+  /**
+   * Gets the current log level. The default level is INFO
+   */
+  getLevel(): Level;
+
+  /**
+   * Sets the enabled logging level.
+   * All the disabled logging methods are replaced by a noop,
+   * so there is not any performance penalty at production using an undesired level
+   * You can also set the logging level using the `LOGOPS_LEVEL` environment variable:
+   * ```
+   * $> LOGOPS_LEVEL=DEBUG node app.js
+   * ```
+   *
+   * @param level one of 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'
+   */
+  setLevel(level: Level): void;
+
+  /**
+   * Sets a global context that should be printed and merged with specific
+   * log context props
+   *
+   * @example
+   * ```
+   * logops.setContextGetter(function getContext() {
+   *  return {
+   *    hostname: require('os').hostname,
+   *    pid: process.pid
+   *  };
+   * });
+   *
+   * logger.info({app: 'server'}, 'Startup');
+   * // {"hostname":"host.local","pid":35502,"app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
+   * ```
+   *  @return The context object
+   */
+  setContextGetter(getContext: () => Context): void;
+  getContext(): Context;
+
+  /**
+   * Specifies the Formatter used for printing traces
+   * @example
+   * ```
+   * logops.setFormat(logops.formatters.dev);
+   * ```
+   *
+   * You can also set the format specifying the formatter with `LOGOPS_FORMAT` environment variable:
+   * @example
+   * ```
+   * $> LOGOPS_FORMAT=json node app.js
+   * ```
+   */
+  setFormat(format: Formatter): void;
+  format: Formatter;
+
+  /**
+   * Creates a child logger with the this logger settings that will append the
+   * passed context to the parent one (if any)
+   * ```
+   * let child = logger.child({hostname: 'host.local'});
+   * child.info({app: 'server'}, 'Startup');
+   * // {"hostname":"host.local","app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
+   * ```
+   */
+  child(context?: Context): Logops;
+
+  /**
+   * The available formatters
+   */
+  formatters: Formatters;
+
+  /**
+   * Logs a debug trace with the provided Context
+   * ```
+   * logger.debug({ip: '127.0.0.0'}, 'Something went wrong');
+   * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"DEBUG","msg":"Something went wrong"}
+   * ```
+   *
+   * @param props the Context to print
+   * @param format A printf-like format string as you will use in console.log()
+   * @param params Additional properties to be coerced in the format string
+   */
+  debug(props: Context, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs an Error as a debug trace.
+   * See Logops.stacktracesWith to print the stack traces
+   * ```
+   * logger.debug(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
+   * ```
+   *
+   * @param error the Error to serialize and print
+   * @param format A printf-like format string as you will use in console.log().
+   *  If not present, the message will be the Error message itself
+   * @param params Additional properties to be coerced in the format string
+   */
+  debug(error: Error, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs a debug trace, as you will do with console.log
+   * ```
+   * logger.debug('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
+   * // {"time":"2015-12-22T16:31:56.184Z","lvl":"DEBUG","msg":"Request is 5 {\"key\":\"value\"} guy"}
+   * ```
+   *
+   * @param format A printf-like format string as you will use in console.log().
+   * @param params Additional properties to be coerced in the format string
+   */
+  debug(format: string, ...params: any[]): void;
+
+  /**
+   * Logs an info trace with the provided Context
+   * ```
+   * logger.info({ip: '127.0.0.0'}, 'Something went wrong');
+   * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"INFO","msg":"Something went wrong"}
+   * ```
+   *
+   * @param props the Context to print
+   * @param format A printf-like format string as you will use in console.log()
+   * @param params Additional properties to be coerced in the format string
+   */
+
+  info(props: Context, format?: string, ...params: any[]): void;
+  /**
+   * Logs an Error as a info trace.
+   * See Logops.stacktracesWith to print the stack traces
+   * ```
+   * logger.info(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
+   * ```
+   *
+   * @param error the Error to serialize and print
+   * @param format A printf-like format string as you will use in console.log().
+   *  If not present, the message will be the Error message itself
+   * @param params Additional properties to be coerced in the format string
+   */
+  info(error: Error, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs a info trace, as you will do with console.log
+   * ```
+   * logger.info('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
+   * // {"time":"2015-12-22T16:31:56.184Z","lvl":"INFO","msg":"Request is 5 {\"key\":\"value\"} guy"}
+   * ```
+   *
+   * @param format A printf-like format string as you will use in console.log().
+   * @param params Additional properties to be coerced in the format string
+   */
+  info(format: string, ...params: any[]): void;
+
+  /**
+   * Logs a warning trace with the provided Context
+   * ```
+   * logger.warn({ip: '127.0.0.0'}, 'Something went wrong');
+   * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"WARN","msg":"Something went wrong"}
+   * ```
+   *
+   * @param props the Context to print
+   * @param format A printf-like format string as you will use in console.log()
+   * @param params Additional properties to be coerced in the format string
+   */
+
+  warn(props: Context, format?: string, ...params: any[]): void;
+  /**
+   * Logs an Error as a warn trace.
+   * See Logops.stacktracesWith to print the stack traces
+   * ```
+   * logger.warn(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
+   * ```
+   *
+   * @param error the Error to serialize and print
+   * @param format A printf-like format string as you will use in console.log().
+   *  If not present, the message will be the Error message itself
+   * @param params Additional properties to be coerced in the format string
+   */
+  warn(error: Error, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs a warn trace, as you will do with console.log
+   * ```
+   * logger.warn('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
+   * // {"time":"2015-12-22T16:31:56.184Z","lvl":"WARN","msg":"Request is 5 {\"key\":\"value\"} guy"}
+   * ```
+   *
+   * @param format A printf-like format string as you will use in console.log().
+   * @param params Additional properties to be coerced in the format string
+   */
+  warn(format: string, ...params: any[]): void;
+
+  /**
+   * Logs an error trace with the provided Context
+   * ```
+   * logger.error({ip: '127.0.0.0'}, 'Something went wrong');
+   * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"ERROR","msg":"Something went wrong"}
+   * ```
+   *
+   * @param props the Context to print
+   * @param format A printf-like format string as you will use in console.log()
+   * @param params Additional properties to be coerced in the format string
+   */
+  error(props: Context, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs an Error as an error trace.
+   * See Logops.stacktracesWith to print the stack traces
+   * ```
+   * logger.error(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
+   * ```
+   *
+   * @param error the Error to serialize and print
+   * @param format A printf-like format string as you will use in console.log().
+   *  If not present, the message will be the Error message itself
+   * @param params Additional properties to be coerced in the format string
+   */
+  error(error: Error, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs a error trace, as you will do with console.log
+   * ```
+   * logger.error('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
+   * // {"time":"2015-12-22T16:31:56.184Z","lvl":"ERROR","msg":"Request is 5 {\"key\":\"value\"} guy"}
+   * ```
+   *
+   * @param format A printf-like format string as you will use in console.log().
+   * @param params Additional properties to be coerced in the format string
+   */
+  error(format: string, ...params: any[]): void;
+
+  /**
+   * Logs a fatal trace with the provided Context
+   * ```
+   * logger.fatal({ip: '127.0.0.0'}, 'Something went wrong');
+   * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"FATAL","msg":"Something went wrong"}
+   * ```
+   *
+   * @param props the Context to print
+   * @param format A printf-like format string as you will use in console.log()
+   * @param params Additional properties to be coerced in the format string
+   */
+  fatal(props: Context, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs an Error as a debug trace.
+   * See Logops.stacktracesWith to print the stack traces
+   * ```
+   * logger.fatal(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
+   * ```
+   *
+   * @param error the Error to serialize and print
+   * @param format A printf-like format string as you will use in console.log().
+   *  If not present, the message will be the Error message itself
+   * @param params Additional properties to be coerced in the format string
+   */
+  fatal(error: Error, format?: string, ...params: any[]): void;
+
+  /**
+   * Logs a fatal trace, as you will do with console.log
+   * ```
+   * logger.fatal('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
+   * // {"time":"2015-12-22T16:31:56.184Z","lvl":"FATAL","msg":"Request is 5 {\"key\":\"value\"} guy"}
+   * ```
+   *
+   * @param format A printf-like format string as you will use in console.log().
+   * @param params Additional properties to be coerced in the format string
+   */
+  fatal(format: string, ...params: any[]): void;
+}
+
+declare let logops: Logops;
+
+export = logops;
 
 /**
  * Log levels
  */
 type Level = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL';
-/**
- * Gets the current log level. The default level is INFO
- */
-export function getLevel(): Level;
-
-/**
- * Sets the enabled logging level.
- * All the disabled logging methods are replaced by a noop,
- * so there is not any performance penalty at production using an undesired level
- * You can also set the logging level using the `LOGOPS_LEVEL` environment variable:
- * ```
- * $> LOGOPS_LEVEL=DEBUG node app.js
- * ```
- *
- * @param level one of 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'
- */
-export function setLevel(level: Level): void;
-
-/**
- * Sets a global context that should be printed and merged with specific
- * log context props
- *
- * @example
- * ```
- * logops.setContextGetter(function getContext() {
- *  return {
- *    hostname: require('os').hostname,
- *    pid: process.pid
- *  };
- * });
- *
- * logger.info({app: 'server'}, 'Startup');
- * // {"hostname":"host.local","pid":35502,"app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
- * ```
- *  @return The context object
- */
-export function setContextGetter(getContext: () => Context): void;
-export function getContext(): Context;
-
-/**
- * Specifies the Formatter used for printing traces
- * @example
- * ```
- * logops.setFormat(logops.formatters.dev);
- * ```
- *
- * You can also set the format specifying the formatter with `LOGOPS_FORMAT` environment variable:
- * @example
- * ```
- * $> LOGOPS_FORMAT=json node app.js
- * ```
- */
-export function setFormat(format: Formatter): void;
-export let format: Formatter;
-
-/**
- * The available formatters
- */
-export let formatters: Formatters;
-
-/**
- * Logs a debug trace with the provided Context
- * ```
- * logger.debug({ip: '127.0.0.0'}, 'Something went wrong');
- * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"DEBUG","msg":"Something went wrong"}
- * ```
- *
- * @param props the Context to print
- * @param format A printf-like format string as you will use in console.log()
- * @param params Additional properties to be coerced in the format string
- */
-export function debug(props:Context, format?:string, ...params:any[]): void;
-
-/**
- * Logs an Error as a debug trace.
- * See Logops.stacktracesWith to print the stack traces
- * ```
- * logger.debug(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
- * ```
- *
- * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log().
- *  If not present, the message will be the Error message itself
- * @param params Additional properties to be coerced in the format string
- */
-export function debug(error:Error, format?:string, ...params:any[]): void;
-
-/**
- * Logs a debug trace, as you will do with console.log
- * ```
- * logger.debug('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
- * // {"time":"2015-12-22T16:31:56.184Z","lvl":"DEBUG","msg":"Request is 5 {\"key\":\"value\"} guy"}
- * ```
- *
- * @param format A printf-like format string as you will use in console.log().
- * @param params Additional properties to be coerced in the format string
- */
-export function debug(format:string, ...params:any[]): void;
-
-/**
- * Logs an info trace with the provided Context
- * ```
- * logger.info({ip: '127.0.0.0'}, 'Something went wrong');
- * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"INFO","msg":"Something went wrong"}
- * ```
- *
- * @param props the Context to print
- * @param format A printf-like format string as you will use in console.log()
- * @param params Additional properties to be coerced in the format string
- */
-
-export function info(props:Context, format?:string, ...params:any[]): void;
-/**
- * Logs an Error as a info trace.
- * See Logops.stacktracesWith to print the stack traces
- * ```
- * logger.info(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
- * ```
- *
- * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log().
- *  If not present, the message will be the Error message itself
- * @param params Additional properties to be coerced in the format string
- */
-export function info(error:Error, format?:string, ...params:any[]): void;
-
-/**
- * Logs a info trace, as you will do with console.log
- * ```
- * logger.info('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
- * // {"time":"2015-12-22T16:31:56.184Z","lvl":"INFO","msg":"Request is 5 {\"key\":\"value\"} guy"}
- * ```
- *
- * @param format A printf-like format string as you will use in console.log().
- * @param params Additional properties to be coerced in the format string
- */
-export function info(format:string, ...params:any[]): void;
-
-/**
- * Logs a warning trace with the provided Context
- * ```
- * logger.warn({ip: '127.0.0.0'}, 'Something went wrong');
- * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"WARN","msg":"Something went wrong"}
- * ```
- *
- * @param props the Context to print
- * @param format A printf-like format string as you will use in console.log()
- * @param params Additional properties to be coerced in the format string
- */
-
-export function warn(props:Context, format?:string, ...params:any[]): void;
-/**
- * Logs an Error as a warn trace.
- * See Logops.stacktracesWith to print the stack traces
- * ```
- * logger.warn(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
- * ```
- *
- * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log().
- *  If not present, the message will be the Error message itself
- * @param params Additional properties to be coerced in the format string
- */
-export function warn(error:Error, format?:string, ...params:any[]): void;
-
-/**
- * Logs a warn trace, as you will do with console.log
- * ```
- * logger.warn('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
- * // {"time":"2015-12-22T16:31:56.184Z","lvl":"WARN","msg":"Request is 5 {\"key\":\"value\"} guy"}
- * ```
- *
- * @param format A printf-like format string as you will use in console.log().
- * @param params Additional properties to be coerced in the format string
- */
-export function warn(format:string, ...params:any[]): void;
-
-/**
- * Logs an error trace with the provided Context
- * ```
- * logger.error({ip: '127.0.0.0'}, 'Something went wrong');
- * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"ERROR","msg":"Something went wrong"}
- * ```
- *
- * @param props the Context to print
- * @param format A printf-like format string as you will use in console.log()
- * @param params Additional properties to be coerced in the format string
- */
-export function error(props:Context, format?:string, ...params:any[]): void;
-
-/**
- * Logs an Error as an error trace.
- * See Logops.stacktracesWith to print the stack traces
- * ```
- * logger.error(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
- * ```
- *
- * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log().
- *  If not present, the message will be the Error message itself
- * @param params Additional properties to be coerced in the format string
- */
-export function error(error:Error, format?:string, ...params:any[]): void;
-
-/**
- * Logs a error trace, as you will do with console.log
- * ```
- * logger.error('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
- * // {"time":"2015-12-22T16:31:56.184Z","lvl":"ERROR","msg":"Request is 5 {\"key\":\"value\"} guy"}
- * ```
- *
- * @param format A printf-like format string as you will use in console.log().
- * @param params Additional properties to be coerced in the format string
- */
-export function error(format:string, ...params:any[]): void;
-
-/**
- * Logs a fatal trace with the provided Context
- * ```
- * logger.fatal({ip: '127.0.0.0'}, 'Something went wrong');
- * // {"ip":"127.0.0.0","time":"2015-12-22T16:33:17.002Z","lvl":"FATAL","msg":"Something went wrong"}
- * ```
- *
- * @param props the Context to print
- * @param format A printf-like format string as you will use in console.log()
- * @param params Additional properties to be coerced in the format string
- */
-export function fatal(props:Context, format?:string, ...params:any[]): void;
-
-/**
- * Logs an Error as a debug trace.
- * See Logops.stacktracesWith to print the stack traces
- * ```
- * logger.fatal(new Error('Out of memory'), 'SYSTEM UNSTABLE. BYE');
- * ```
- *
- * @param error the Error to serialize and print
- * @param format A printf-like format string as you will use in console.log().
- *  If not present, the message will be the Error message itself
- * @param params Additional properties to be coerced in the format string
- */
-export function fatal(error:Error, format?:string, ...params:any[]): void;
-
-/**
- * Logs a fatal trace, as you will do with console.log
- * ```
- * logger.fatal('Request %s %d %j', 'is', 5, {key: 'value'}, 'guy');
- * // {"time":"2015-12-22T16:31:56.184Z","lvl":"FATAL","msg":"Request is 5 {\"key\":\"value\"} guy"}
- * ```
- *
- * @param format A printf-like format string as you will use in console.log().
- * @param params Additional properties to be coerced in the format string
- */
-export function fatal(format:string, ...params:any[]): void;
 
 /**
  * A key value map that should be printed and serialized as first class
  * citizien in the traces.
  */
 interface Context {
-    [key: string]: any;
+  [key: string]: any;
 }
 
 /**
@@ -279,26 +298,26 @@ interface Context {
  * string ready to be written to a Stream
  */
 interface Formatter {
-    /**
-     * Format the user input as a readable string ready to be written to a Stream
-     * @param level One of the following values
-     *      ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
-     * @param context Additional information to add to the trace
-     * @param message The main message to be added to the trace
-     * @param args More arguments provided to the log function
-     * @param err A cause error used to log extra information
-     */
-    format(level: string, context:Context, message:string, args:any[], err?:Error): string;
+  /**
+   * Format the user input as a readable string ready to be written to a Stream
+   * @param level One of the following values
+   *      ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
+   * @param context Additional information to add to the trace
+   * @param message The main message to be added to the trace
+   * @param args More arguments provided to the log function
+   * @param err A cause error used to log extra information
+   */
+  format(level: string, context: Context, message: string, args: any[], err?: Error): string;
 }
 
 /**
  * The additional properties in a DevFormatter
  */
 interface DevFormatter extends Formatter {
-    /**
-     * Context properties keys that should be skipped from printing in dev format
-     */
-    omit: string[];
+  /**
+   * Context properties keys that should be skipped from printing in dev format
+   */
+  omit: string[];
 }
 
 /**
@@ -306,30 +325,30 @@ interface DevFormatter extends Formatter {
  * is printed is located here
  */
 interface Formatters {
-    /**
-     *  Formats a trace message in JSON format
-     */
-    json: Formatter;
-    /**
-     * Formats a trace message with some nice TTY colors
-     */
-    dev: DevFormatter;
-    /**
-     * Formats a trace message with fields separated by pipes.
-     * @deprecated
-     */
-    pipe: Formatter;
-    /**
-     * Array of logger levels that will print error stacktraces
-     * Defaults to `['ERROR', 'FATAL']
-     */
-    stacktracesWith: Level[];
-    /**
-     * Sets a value for those fields that are not available in the context. This field
-     * will only be used in the 'pipes' formatter.
-     *
-     * @param str New value for not available fields.
-     * @deprecated
-     */
-    setNotAvailable(str: string): void;
+  /**
+   *  Formats a trace message in JSON format
+   */
+  json: Formatter;
+  /**
+   * Formats a trace message with some nice TTY colors
+   */
+  dev: DevFormatter;
+  /**
+   * Formats a trace message with fields separated by pipes.
+   * @deprecated
+   */
+  pipe: Formatter;
+  /**
+   * Array of logger levels that will print error stacktraces
+   * Defaults to `['ERROR', 'FATAL']
+   */
+  stacktracesWith: Level[];
+  /**
+   * Sets a value for those fields that are not available in the context. This field
+   * will only be used in the 'pipes' formatter.
+   *
+   * @param str New value for not available fields.
+   * @deprecated
+   */
+  setNotAvailable(str: string): void;
 }

--- a/lib/logops.js
+++ b/lib/logops.js
@@ -23,8 +23,17 @@ module.exports = logops();
 
 function noop() {};
 
-function logops() {
-  let currentLevel;
+function logops(options) {
+  let opts = Object.assign({
+    level: process.env.LOGOPS_LEVEL || DEFAULT_LEVEL,
+    format: formatters[process.env.LOGOPS_FORMAT] || (process.env.NODE_ENV === 'development' ?
+      formatters.dev :
+      formatters.json
+    ),
+    getContext: noop,
+    stream: process.stdout,
+  }, options);
+
   let API = {};
   /**
    * Internal private function that implements a decorator to all
@@ -34,7 +43,7 @@ function logops() {
    *   ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
    */
   function logWrap(level) {
-    var context, message, args, trace, err;
+    let context, message, args, trace, err;
 
     if (arguments[1] instanceof Error) {
       // log.<level>(err, ...)
@@ -77,11 +86,11 @@ function logops() {
    * @param {String} level
    */
   function setLevel(level) {
-    currentLevel = level || DEFAULT_LEVEL;
-    var logLevelIndex = levels.indexOf(currentLevel.toUpperCase());
+    opts.level = level;
+    let logLevelIndex = levels.indexOf(opts.level.toUpperCase());
 
     levels.forEach((logLevel) => {
-      var fn;
+      let fn;
       if (logLevelIndex <= levels.indexOf(logLevel)) {
         fn = logWrap.bind(global, logLevel);
       } else {
@@ -98,7 +107,7 @@ function logops() {
    *     ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
    */
   function getLevel() {
-    return currentLevel || DEFAULT_LEVEL;
+    return opts.level;
   }
 
   /**
@@ -117,7 +126,7 @@ function logops() {
      * The stream where the logger will write string traces
      * Defaults to process.stdout
      */
-    stream: process.stdout,
+    stream: opts.stream,
     setStream: (stream) => {
       API.stream = stream;
     },
@@ -178,7 +187,7 @@ function logops() {
      *
      * @return {Object} The context object
      */
-    getContext: noop,
+    getContext: opts.getContext,
     setContextGetter: (fn) => {
       API.getContext = fn;
     },
@@ -212,8 +221,7 @@ function logops() {
      *
      * @return {String} The trace formatted
      */
-    format: formatters[process.env.LOGOPS_FORMAT] ||
-      (process.env.NODE_ENV === 'development' ? formatters.dev : formatters.json),
+    format: opts.format,
     setFormat: (format) => {
       API.format = format;
     },
@@ -228,9 +236,33 @@ function logops() {
      *
      * @return {Object} The available formatters.
      */
-    formatters: formatters
+    formatters: formatters,
+
+    /**
+     * Creates a child logger with the this logger settings that will append the
+     * passed context to the parent one (if any)
+     * ```
+     * let child = logger.child({hostname: 'host.local'});
+     * child.info({app: 'server'}, 'Startup');
+     * // {"hostname":"host.local","app":"server","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
+     * ```
+     */
+    child: function(localContext) {
+      // the current limitation for this approach is that child
+      // loggers will overwrite the parent and localcontext when
+      // calling againg `child.setContextGetter(fn)` or assign a function
+      // to `child.getContext = fn`
+      // But as the context is specified then creating the child, we can
+      // considerer it a corner case and dont optimize for the use case
+      return logops({
+        level: API.getLevel(),
+        getContext: () => Object.assign({}, API.getContext(), localContext),
+        format: API.format,
+        stream: API.stream,
+      });
+    }
   };
 
-  setLevel(process.env.LOGOPS_LEVEL);
+  setLevel(opts.level);
   return API;
 }

--- a/test/logops.typings.ts
+++ b/test/logops.typings.ts
@@ -63,3 +63,6 @@ logops.fatal(new Error('Error'), 'Some');
 logops.fatal(new Error('Error'), 'Some %d', 1);
 logops.fatal('Some');
 logops.fatal('Some %d', 1);
+
+let child = logops.child();
+child.debug('Hi');


### PR DESCRIPTION
create an specialized logger with bound static context/properties. The child logger
will inherit its parent config: level, format, stream and context. If the parent logger has a context returned by `parent.getContext()`, the conflicting child logger context will take precedence
```js
let child = logger.child({component: 'client'});
child.info('Startup');
// {"component":"client","time":"2015-12-23T11:47:25.862Z","lvl":"INFO","msg":"Startup"}
```

Closes #35 