### PR TITLE
Update package.json: fix colors to current expected version for logops

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "performant"
   ],
   "dependencies": {
-    "colors": "^1.1.2",
+    "colors": "1.1.2",
     "lodash": "^4.17.15",
     "safe-json-stringify": "^1.2.0",
     "serr": "^1.0.1"


### PR DESCRIPTION
latests versions of colors ( 1.4.1 and 1.4.2) are broken due to https://snyk.io/blog/open-source-npm-packages-colors-faker/

@jmendiara could you merge it please?

And then a new version of logops should be published: https://www.npmjs.com/package/logops